### PR TITLE
Allow easier access to CeresPose's data_

### DIFF
--- a/cartographer/mapping/internal/pose_graph/ceres_pose.cc
+++ b/cartographer/mapping/internal/pose_graph/ceres_pose.cc
@@ -24,7 +24,7 @@ CeresPose::Data FromPose(const transform::Rigid3d& pose) {
   return CeresPose::Data{ {{pose.translation().x(), pose.translation().y(),
                                pose.translation().z()}},
                           {{pose.rotation().w(), pose.rotation().x(),
-                               pose.rotation().rotation().y(), pose.rotation().rotation.z()}}};
+                               pose.rotation().y(), pose.rotation().z()}}};
 }
 
 CeresPose::CeresPose(

--- a/cartographer/mapping/internal/pose_graph/ceres_pose.cc
+++ b/cartographer/mapping/internal/pose_graph/ceres_pose.cc
@@ -20,16 +20,19 @@ namespace cartographer {
 namespace mapping {
 namespace pose_graph {
 
+CeresPose::Data FromPose(const transform::Rigid3d& pose) {
+  return CeresPose::Data{ {{pose.translation().x(), pose.translation().y(),
+                               pose.translation().z()}},
+                          {{pose.rotation().w(), pose.rotation().x(),
+                               pose.rotation().rotation().y(), pose.rotation().rotation.z()}}};
+}
+
 CeresPose::CeresPose(
-    const transform::Rigid3d& rigid,
+    const transform::Rigid3d& pose,
     std::unique_ptr<ceres::LocalParameterization> translation_parametrization,
     std::unique_ptr<ceres::LocalParameterization> rotation_parametrization,
     ceres::Problem* problem)
-    : data_(std::make_shared<CeresPose::Data>(
-          CeresPose::Data{{{rigid.translation().x(), rigid.translation().y(),
-                            rigid.translation().z()}},
-                          {{rigid.rotation().w(), rigid.rotation().x(),
-                            rigid.rotation().y(), rigid.rotation().z()}}})) {
+    : data_(std::make_shared<CeresPose::Data>(FromPose(pose))) {
   problem->AddParameterBlock(data_->translation.data(), 3,
                              translation_parametrization.release());
   problem->AddParameterBlock(data_->rotation.data(), 4,

--- a/cartographer/mapping/internal/pose_graph/ceres_pose.h
+++ b/cartographer/mapping/internal/pose_graph/ceres_pose.h
@@ -44,12 +44,15 @@ class CeresPose {
   double* rotation() { return data_->rotation.data(); }
   const double* rotation() const { return data_->rotation.data(); }
 
- private:
   struct Data {
     std::array<double, 3> translation;
     // Rotation quaternion as (w, x, y, z).
     std::array<double, 4> rotation;
   };
+
+  Data& data() { return *data_; }
+
+ private:
   std::shared_ptr<Data> data_;
 };
 

--- a/cartographer/mapping/internal/pose_graph/ceres_pose.h
+++ b/cartographer/mapping/internal/pose_graph/ceres_pose.h
@@ -56,6 +56,8 @@ class CeresPose {
   std::shared_ptr<Data> data_;
 };
 
+CeresPose::Data FromPose(const transform::Rigid3d& pose);
+
 }  // namespace pose_graph
 }  // namespace mapping
 }  // namespace cartographer


### PR DESCRIPTION
Allow easier modification of the optimization problem's variables by
introducing a `data()` getter, which returns a reference to `CeresPose::Data` contained inside the `CeresPose`. This allows setting the translation and rotation arrays using the assignment operator.

Also factor out conversion to `CeresPose::Data` into `FromPose()`, which transforms a `Rigid3d` pose into `CeresPose::Data`, similar to `FromPose` for 2D.