### PR TITLE
Support for initial pose of first trajectory.

### DIFF
--- a/cartographer/mapping/internal/3d/pose_graph_3d.cc
+++ b/cartographer/mapping/internal/3d/pose_graph_3d.cc
@@ -1018,6 +1018,9 @@ void PoseGraph3D::SetInitialTrajectoryPose(const int from_trajectory_id,
 
 transform::Rigid3d PoseGraph3D::GetInterpolatedGlobalTrajectoryPose(
     const int trajectory_id, const common::Time time) const {
+  if (trajectory_id == -1){
+    return transform::Rigid3d{};
+  }
   CHECK_GT(data_.trajectory_nodes.SizeOfTrajectoryOrZero(trajectory_id), 0);
   const auto it = data_.trajectory_nodes.lower_bound(trajectory_id, time);
   if (it == data_.trajectory_nodes.BeginOfTrajectory(trajectory_id)) {

--- a/cartographer/mapping/internal/connected_components.cc
+++ b/cartographer/mapping/internal/connected_components.cc
@@ -51,6 +51,9 @@ void ConnectedComponents::Union(const int trajectory_id_a,
 }
 
 int ConnectedComponents::FindSet(const int trajectory_id) {
+  if (trajectory_id == -1){
+      return -1;
+  }
   auto it = forest_.find(trajectory_id);
   CHECK(it != forest_.end());
   if (it->first != it->second) {


### PR DESCRIPTION
Allow the user to specify a trajectories relative pose with respect to the
origin by passing -1 as the trajectory_id.

@ojura, would you be so kind to take a look?